### PR TITLE
Fix Ubuntu digest update workflow

### DIFF
--- a/.github/workflows/update-dockerfile.yml
+++ b/.github/workflows/update-dockerfile.yml
@@ -38,7 +38,7 @@ jobs:
           cp base-images.json "${tmp}"
 
           for version in 24.04 26.04; do
-            digest="$(docker buildx imagetools inspect "ubuntu:${version}" --format '{{.Digest}}')"
+            digest="$(docker buildx imagetools inspect "ubuntu:${version}" --format '{{.Manifest.Digest}}')"
             if ! printf '%s\n' "${digest}" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
               echo "Failed to parse ubuntu:${version} digest" >&2
               exit 1


### PR DESCRIPTION
## Summary
- update the Buildx imagetools template path from `{{.Digest}}` to `{{.Manifest.Digest}}`
- restores Ubuntu base digest parsing in the scheduled Dockerfile update workflow

## Verification
- `docker buildx imagetools inspect ubuntu:24.04 --format '{{.Manifest.Digest}}'`
- `docker buildx imagetools inspect ubuntu:26.04 --format '{{.Manifest.Digest}}'`