### PR TITLE
Allow update workflow to create pull requests

### DIFF
--- a/.github/workflows/update-dockerfile.yml
+++ b/.github/workflows/update-dockerfile.yml
@@ -91,6 +91,7 @@ jobs:
           app-id: ${{ vars.AUTOMATION_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
           permission-contents: write
+          permission-pull-requests: write
 
       - name: Create Pull Request # zizmor: ignore[superfluous-actions]
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1


### PR DESCRIPTION
## Summary
- request `pull-requests: write` on the GitHub App token used by the Dockerfile update workflow
- fixes the create-pull-request failure after the workflow successfully updates `cron-python-update`

## Failure
The scheduled update job failed with:
`Resource not accessible by integration - https://docs.github.com/rest/pulls/pulls#create-a-pull-request`

## Verification
- inspected failing job `27125660460 / 80053458476`
- confirmed the digest update and Dockerfile generation steps passed; failure is isolated to PR creation