### PR TITLE
Drop optional Python Tk and Bluetooth build deps

### DIFF
--- a/python/generate_dockerfile.sh
+++ b/python/generate_dockerfile.sh
@@ -42,6 +42,11 @@ function install_python() {
 
     cat Dockerfile_trunc >>"${output_file}"
 
+    # Drop optional CPython extension build dependencies that this base image
+    # does not need: Bluetooth socket support and tkinter/Tk bindings.
+    sed -i -e '/^[[:space:]]*libbluetooth-dev \\$/d' "${output_file}"
+    sed -i -e '/^[[:space:]]*tk-dev \\$/d' "${output_file}"
+
     # Now, to avoid GPG problems
     # https://github.com/f-secure-foundry/usbarmory-debian-base_image/issues/9
     sed -i -e 's|GNUPGHOME="$(mktemp -d)"; export GNUPGHOME;|GNUPGHOME="$(mktemp -d)"; export GNUPGHOME;\\\n\t# Fix to avoid GPG server problem\\\n\techo "disable-ipv6" >> "${GNUPGHOME}\/dirmngr.conf";|'  "${output_file}"

--- a/python/ubuntu24.04/Dockerfile_3.12
+++ b/python/ubuntu24.04/Dockerfile_3.12
@@ -43,7 +43,6 @@ RUN set -eux; \
 		dpkg-dev \
 		gcc \
 		gnupg \
-		libbluetooth-dev \
 		libbz2-dev \
 		libc6-dev \
 		libdb-dev \
@@ -55,7 +54,6 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
-		tk-dev \
 		uuid-dev \
 		wget \
 		xz-utils \
@@ -161,6 +159,5 @@ RUN set -eux; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
 		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
-
 
 

--- a/python/ubuntu24.04/Dockerfile_3.13
+++ b/python/ubuntu24.04/Dockerfile_3.13
@@ -38,7 +38,6 @@ RUN set -eux; \
 		dpkg-dev \
 		gcc \
 		gnupg \
-		libbluetooth-dev \
 		libbz2-dev \
 		libc6-dev \
 		libdb-dev \
@@ -50,7 +49,6 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
-		tk-dev \
 		uuid-dev \
 		wget \
 		xz-utils \
@@ -156,6 +154,5 @@ RUN set -eux; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
 		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
-
 
 

--- a/python/ubuntu24.04/Dockerfile_3.14
+++ b/python/ubuntu24.04/Dockerfile_3.14
@@ -37,7 +37,6 @@ RUN set -eux; \
 		dpkg-dev \
 		gcc \
 		gnupg \
-		libbluetooth-dev \
 		libbz2-dev \
 		libc6-dev \
 		libdb-dev \
@@ -50,7 +49,6 @@ RUN set -eux; \
 		libssl-dev \
 		libzstd-dev \
 		make \
-		tk-dev \
 		uuid-dev \
 		wget \
 		xz-utils \
@@ -148,6 +146,5 @@ RUN set -eux; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
 		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
-
 
 

--- a/python/ubuntu26.04/Dockerfile_3.12
+++ b/python/ubuntu26.04/Dockerfile_3.12
@@ -43,7 +43,6 @@ RUN set -eux; \
 		dpkg-dev \
 		gcc \
 		gnupg \
-		libbluetooth-dev \
 		libbz2-dev \
 		libc6-dev \
 		libdb-dev \
@@ -55,7 +54,6 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
-		tk-dev \
 		uuid-dev \
 		wget \
 		xz-utils \
@@ -161,6 +159,5 @@ RUN set -eux; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
 		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
-
 
 

--- a/python/ubuntu26.04/Dockerfile_3.13
+++ b/python/ubuntu26.04/Dockerfile_3.13
@@ -38,7 +38,6 @@ RUN set -eux; \
 		dpkg-dev \
 		gcc \
 		gnupg \
-		libbluetooth-dev \
 		libbz2-dev \
 		libc6-dev \
 		libdb-dev \
@@ -50,7 +49,6 @@ RUN set -eux; \
 		libsqlite3-dev \
 		libssl-dev \
 		make \
-		tk-dev \
 		uuid-dev \
 		wget \
 		xz-utils \
@@ -156,6 +154,5 @@ RUN set -eux; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
 		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
-
 
 

--- a/python/ubuntu26.04/Dockerfile_3.14
+++ b/python/ubuntu26.04/Dockerfile_3.14
@@ -37,7 +37,6 @@ RUN set -eux; \
 		dpkg-dev \
 		gcc \
 		gnupg \
-		libbluetooth-dev \
 		libbz2-dev \
 		libc6-dev \
 		libdb-dev \
@@ -50,7 +49,6 @@ RUN set -eux; \
 		libssl-dev \
 		libzstd-dev \
 		make \
-		tk-dev \
 		uuid-dev \
 		wget \
 		xz-utils \
@@ -148,6 +146,5 @@ RUN set -eux; \
 		[ ! -e "/usr/local/bin/$dst" ]; \
 		ln -svT "$src" "/usr/local/bin/$dst"; \
 	done
-
 
 


### PR DESCRIPTION
## Summary

- remove `tk-dev` and `libbluetooth-dev` from all generated Python Dockerfiles
- update `python/generate_dockerfile.sh` so regenerated Dockerfiles keep those optional CPython build deps removed

## Validation

- `rtk git diff --check`
- `rtk env UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uvx zizmor --pedantic --format=github .github/`
- representative local build:
  - `rtk docker build --build-arg UBUNTU_BASE_IMAGE=ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54 -f python/ubuntu24.04/Dockerfile_3.12 -t giskard-python-no-tk-bluetooth:3.12-ubuntu24.04 python`
  - build showed Bluetooth headers were not detected
  - build showed `_tkinter` as a missing optional module
- runtime smoke checks on the built image:
  - Python, SSL, and SQLite import successfully
  - `socket.AF_BLUETOOTH` is absent
  - `_tkinter` spec is `None`
