### PR TITLE
Fix Dockerfile update verification

### DIFF
--- a/.github/workflows/update-dockerfile.yml
+++ b/.github/workflows/update-dockerfile.yml
@@ -80,7 +80,7 @@ jobs:
               echo "Checking $f"
               grep -Fq "ARG UBUNTU_BASE_IMAGE=${image}" "$f"
               grep -Fq "/${debian_variant}-${debian_version}/Dockerfile" "$f"
-              grep -q '^FROM ${UBUNTU_BASE_IMAGE}$' "$f"
+              grep -q '^FROM ${UBUNTU_BASE_IMAGE} AS dev$' "$f"
             done
           done
 


### PR DESCRIPTION
## Summary
- update the Dockerfile verifier to match the generated named dev stage
- keep the scheduled/manual Dockerfile update workflow aligned with current generated Dockerfiles

## Validation
- reproduced the failed verification loop locally
- rtk git diff --check
- Python/YAML workflow parse
- rtk env UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uvx zizmor --pedantic --format=github .github/