### PR TITLE
Document image signing and reduce metadata writes

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -304,26 +304,26 @@ jobs:
         env:
           SUBJECT_NAME: ${{ steps.image.outputs.subject_name }}
 
-      - name: Sign final image tags
+      - name: Sign final image digest
         run: |
           set -euo pipefail
 
-          while IFS= read -r image_ref; do
-            cosign sign --yes "${image_ref}"
-          done < image-tags.txt
+          cosign sign --yes "${DIGEST_REF}"
+        env:
+          DIGEST_REF: ${{ steps.image.outputs.digest_ref }}
 
       - name: Attach platform SBOM attestations
         run: |
           set -euo pipefail
 
-          while IFS= read -r image_ref; do
-            for sbom in sbom-*.spdx.json; do
-              cosign attest --yes \
-                --predicate "${sbom}" \
-                --type spdxjson \
-                "${image_ref}"
-            done
-          done < image-tags.txt
+          for sbom in sbom-*.spdx.json; do
+            cosign attest --yes \
+              --predicate "${sbom}" \
+              --type spdxjson \
+              "${DIGEST_REF}"
+          done
+        env:
+          DIGEST_REF: ${{ steps.image.outputs.digest_ref }}
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0

--- a/README.md
+++ b/README.md
@@ -41,3 +41,41 @@ workflow builds the `3.12`, `3.13`, and `3.14` `dev` and `runtime` images for
 both configured Ubuntu bases and both configured platform runners, then
 publishes multi-platform manifests to Quay. Existing non-Ubuntu-specific
 variant tags continue to point at the Ubuntu `24.04` images for compatibility.
+
+## Published Image Metadata
+
+Final Quay images are published with Sigstore/cosign keyless signatures, SPDX
+JSON SBOM attestations, and GitHub build provenance. The publish workflow
+resolves each final multi-platform manifest digest, signs that immutable digest,
+attaches one SBOM attestation for each platform child manifest, and publishes
+GitHub provenance for the same final digest.
+
+SBOMs are generated from the pushed image digests. This includes `runtime`
+images, even though they are built `FROM scratch`: Syft scans the final runtime
+filesystem by digest, so the SBOM describes only files copied into the runtime
+image and does not reuse the `dev` image SBOM.
+
+Quay can show attached cosign and provenance metadata as `sha256-...` entries in
+the tag list. Those entries are OCI signature or attestation artifacts attached
+to the image digest, not additional runnable Python image tags. To limit Quay
+metadata noise, the workflow signs and attests the resolved digest once for each
+final manifest rather than signing every alias tag that points at that digest.
+
+Verify a published image with:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp '^https://github\.com/Giskard-AI/docker-images/\.github/workflows/python\.yml@refs/heads/main$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  quay.io/giskard/python:3.13-dev
+```
+
+Verify attached SPDX SBOM attestations with:
+
+```bash
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-identity-regexp '^https://github\.com/Giskard-AI/docker-images/\.github/workflows/python\.yml@refs/heads/main$' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  quay.io/giskard/python:3.13-dev
+```


### PR DESCRIPTION
## Summary
- document final image cosign signing, SBOM attestations, provenance, and Quay sha256 metadata entries
- sign and attest the resolved final manifest digest once instead of every alias tag
- keep tag verification against the same expected GitHub Actions identity

## Test Plan
- rtk git diff --check origin/main...HEAD
- workflow YAML parse with PyYAML
- rtk env UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uvx zizmor --pedantic --format=github .github/