### PR TITLE
Avoid Dockerfile generator trailing blank churn

### DIFF
--- a/python/generate_dockerfile.sh
+++ b/python/generate_dockerfile.sh
@@ -226,7 +226,6 @@ for ubuntu_version in ${ubuntu_versions}; do
         write_header "${output_file}" "${ubuntu_base_image}" 'FROM ${UBUNTU_BASE_IMAGE} AS dev'
         install_python "${output_file}" "${python_version}" "${debian_variant}" "${debian_version}"
         append_runtime_image "${output_file}"
-        echo '' >>"${output_file}"
     done
 done
 


### PR DESCRIPTION
## Summary
- remove the extra blank line appended after generated Dockerfiles
- confirm regeneration leaves the committed Dockerfiles unchanged

## Context
PR #154 is whitespace-only: the scheduled generator added one trailing blank line to each generated Dockerfile. This change fixes the generator instead of merging no-op Dockerfile churn.

## Test Plan
- rtk ./python/generate_dockerfile.sh
- rtk git diff --check
- workflow YAML parse with PyYAML
- rtk env UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools uvx zizmor --pedantic --format=github .github/